### PR TITLE
nsight-compute v2025.4.1.2

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -8,8 +8,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.28'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -10,8 +10,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.28'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/README.md
+++ b/README.md
@@ -138,12 +138,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -170,7 +170,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/nsight-compute-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-1
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "nsight-compute" %}
-{% set version = "2025.3.1.4" %}
+{% set version = "2025.4.0.12" %}
 {% set version_split = version.split(".")[0]+"."+version.split(".")[1]+"."+version.split(".")[2] %}
-{% set cuda_version = "13.0" %}
+{% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64]
@@ -15,9 +15,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/nsight_compute/{{ platform }}/nsight_compute-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: d3c0a0402511034c58227b817cbfed599765f32dc662cdcda58922247b52dd7a  # [linux64]
-  sha256: 562acdb72942ba3250fbda1d0a5b45d9d8bebf7295049846d16ffbdb457f9d28  # [aarch64]
-  sha256: 0ad1c310f38cdfc17e85f6efa2da60e7628bd2db81eba8ec487ab6d49c1bcdef  # [win]
+  sha256: 75fca7c10a73f76cec6e5d97dd48cd480806c9222632f5df5f53b19154c75e0e  # [linux64]
+  sha256: e6d378cc697de0733ce9f62fd137233bfc525f5365337e5fd44ac831fe785a5e  # [aarch64]
+  sha256: af37cee796b6e0911f08795643b5ada2121d424186661300b89de8e534cce5f6  # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nsight-compute" %}
-{% set version = "2025.4.0.12" %}
+{% set version = "2025.4.1.2" %}
 {% set version_split = version.split(".")[0]+"."+version.split(".")[1]+"."+version.split(".")[2] %}
 {% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
@@ -15,9 +15,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/nsight_compute/{{ platform }}/nsight_compute-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: 75fca7c10a73f76cec6e5d97dd48cd480806c9222632f5df5f53b19154c75e0e  # [linux64]
-  sha256: e6d378cc697de0733ce9f62fd137233bfc525f5365337e5fd44ac831fe785a5e  # [aarch64]
-  sha256: af37cee796b6e0911f08795643b5ada2121d424186661300b89de8e534cce5f6  # [win]
+  sha256: 5d41301bdfa2bfb958e068f7cfd5de5a465e50aca6903a24ca84c70dd676622c  # [linux64]
+  sha256: 1cdcff91da6f1914cad687db4dff5abab7a69c12b7dea60224268e155408c4a3  # [aarch64]
+  sha256: cb26a33427f34606b063166538f00f8eced3e0bc1c5bc21c1385d0e270ceefab  # [win]
 
 build:
   number: 0


### PR DESCRIPTION
nsight-compute 2025.4.1.2

**Destination channel:** defaults

### Links

- [PKG-12021](https://anaconda.atlassian.net/browse/PKG-12020) 
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- CUDA 13.1 release


[PKG-12021]: https://anaconda.atlassian.net/browse/PKG-12021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ