### PR TITLE
nsight-compute v2025.2.1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+#   - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,10 @@
+# Please see the note on "arm-variant-feedstock" cbc.yaml file regarding tegra builds
 arm_variant_type: # [aarch64]
   - sbsa          # [linux and aarch64]
-  - tegra         # [linux and aarch64]
+  #- tegra         # [linux and aarch64]
 c_stdlib_version:  # [linux]
-  - 2.17           # [linux and aarch64]
-  - 2.28           # [linux and aarch64]
+  - "2.28"           # [linux and aarch64]
+  #- "2.28"           # [linux and aarch64]
 zip_keys:               # [linux and aarch64]
   -                     # [linux and aarch64]
     - arm_variant_type  # [linux and aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,11 +22,16 @@ source:
   sha256: e9d558654c98d83049969d133b98922b53ab8f4e3ba9e0a37bdb5e2ff300b7de  # [win]
 
 build:
-  number: 1
+  number: 0
   binary_relocation: false
-  skip: true  # [osx or ppc64le]
+  skip: true  # [osx]
   missing_dso_whitelist:
     - '*'
+  overlinking_ignore_patterns:
+    # Ignore 32-bit libraries for overlinking checks
+    - '*linux-desktop-glibc_2_11_3-x86*'  # [linux]
+    # Added for LIEF 'not a valid TAG' error on linux-64 and linux-aarch64
+    - 'nsight-compute-2025.2.1/*'  # [linux]
 
 requirements:
   build:
@@ -46,7 +51,7 @@ requirements:
     - libopengl-devel      # [linux]
     - krb5
     - libglib
-    - libxcb
+    - libxcb               # [linux]
     - libxkbcommon         # [linux]
     - libxkbfile           # [linux]
     - libzlib
@@ -87,23 +92,22 @@ test:
     - if exist %LIBRARY_PREFIX%\nsight-compute\{{ version_split }}\lib exit 1  # [win]
     - if not exist %PREFIX%\Scripts\ncu.bat exit 1                             # [win]
     - ncu --version                                                            # [build_platform == target_platform]
-    # ncu-ui test can be enabled for aarch64 once GLIBC 2.28 is made available
-    # https://github.com/conda-forge/conda-forge.github.io/issues/1941
-    # ncu-ui test is currently failing on linux64 as well due to missing x11 libs
-    # https://github.com/conda-forge/nsight-compute-feedstock/issues/26
-    # - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'ncu-ui --help-all'            # [linux64]
+    # ncu-ui cannot find 'libOpenGL.so.0'
+    #- DISPLAY=localhost:1.0 xvfb-run -a bash -c 'ncu-ui --help-all'            # [linux]
 
 about:
   home: https://developer.nvidia.com/nsight-compute
   license_file: LICENSE
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: NVIDIA Nsight Compute is an interactive kernel profiler for CUDA applications
   description: |
     NVIDIA Nsight Compute is an interactive kernel profiler for CUDA
     applications. It provides detailed performance metrics and API
     debugging via a user interface and command line tool.
   doc_url: https://docs.nvidia.com/nsight-compute/NsightCompute/index.html
+  dev_url: https://docs.nvidia.com/nsight-compute/NsightCompute/index.html
 
 extra:
   recipe-maintainers:

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,1 +1,0 @@
-xorg-x11-server-Xvfb


### PR DESCRIPTION
nsight-compute 2025.2.1.3

**Destination channel:** defaults

### Links

- [PKG-12764](https://anaconda.atlassian.net/browse/PKG-12764) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Ignoring `nsight-compute-2025.2.1/*` pattern for overlinking on `linux-64` and `linux-aarch64` due to LIEF `not a valid TAG` error.
- Ignoring `*linux-desktop-glibc_2_11_3-x86*` pattern for overlinking might not be necessary due to the addition of `nsight-compute-2025.2.1/*`. However, I'd like to keep it as it is because, when the LIEF errors get resolved, we will need it.


[PKG-12764]: https://anaconda.atlassian.net/browse/PKG-12764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ